### PR TITLE
Fix authorization bypass in updateUser endpoint

### DIFF
--- a/server/src/router/userRouter.ts
+++ b/server/src/router/userRouter.ts
@@ -1,5 +1,6 @@
 import { protectedProcedure, router } from "../trpc.js"
 import { z } from "zod"
+import { TRPCError } from "@trpc/server"
 import { userTable, drizzleOrm } from "@fsb/drizzle"
 const { eq, or, count, asc, ilike, and } = drizzleOrm
 
@@ -14,6 +15,9 @@ const userRouter = router({
       })
     )
     .mutation(async (opts) => {
+      if (opts.ctx.user.id !== opts.input.id) {
+        throw new TRPCError({ code: "FORBIDDEN", message: "Cannot update other users" })
+      }
       const db = opts.ctx.db
 
       const user = await db


### PR DESCRIPTION
## Summary
- **Security fix**: Any authenticated user could update any other user's profile (name, email, age) by passing an arbitrary `id` to the `updateUser` mutation
- Adds an authorization check that the authenticated user's ID matches the target user ID, returning a `FORBIDDEN` error otherwise

## Test plan
- [ ] Authenticate as user A, attempt to update user B's profile — should get FORBIDDEN error
- [ ] Authenticate as user A, update own profile — should succeed as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)